### PR TITLE
iOS: Fix localized numbers in transaction date for some Arab countries

### DIFF
--- a/extension-iap/src/iap_ios.mm
+++ b/extension-iap/src/iap_ios.mm
@@ -233,6 +233,7 @@ static void CopyTransaction(SKPaymentTransaction* transaction, IAPTransaction* o
     }
 
     NSDateFormatter *dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
+    [dateFormatter setLocale: [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZ"];
 
     out->ident = strdup([transaction.payment.productIdentifier UTF8String]);


### PR DESCRIPTION
Transactions from Egypt have date with local numbers (٢٠١٩-١٢-٢٤T١٤:٥٧:٤٠+03:00)