### PR TITLE
Pending transactions fix

### DIFF
--- a/docs/_data/api.yml
+++ b/docs/_data/api.yml
@@ -163,6 +163,13 @@
 
 #*****************************************************************************************************
 
+  - name: process_pending_transactions
+    type: function
+    desc: Process transactions still unprocessed from previous session if any. Transactions will be
+          processed with callback function set with `set_listener` function
+
+#*****************************************************************************************************
+
   - name: set_listener
     type: function
     desc: Set the callback function to receive purchase transaction events.

--- a/extension-iap/src/iap_android.cpp
+++ b/extension-iap/src/iap_android.cpp
@@ -50,6 +50,12 @@ struct IAP
 
 static IAP g_IAP;
 
+static int IAP_ProcessPendingTransactions(lua_State* L)
+{
+    //todo handle pending transactions if there is such thing on Android
+    return 0;
+}
+
 static int IAP_List(lua_State* L)
 {
     int top = lua_gettop(L);
@@ -187,6 +193,7 @@ static const luaL_reg IAP_methods[] =
     {"restore", IAP_Restore},
     {"set_listener", IAP_SetListener},
     {"get_provider_id", IAP_GetProviderId},
+    {"process_pending_transactions", IAP_ProcessPendingTransactions},
     {0, 0}
 };
 

--- a/extension-iap/src/iap_emscripten.cpp
+++ b/extension-iap/src/iap_emscripten.cpp
@@ -77,6 +77,11 @@ static void IAPList_Callback(void* luacallback, const char* result_json)
     dmScript::TeardownCallback(callback);
 }
 
+static int IAP_ProcessPendingTransactions(lua_State* L)
+{
+    return 0;
+}
+
 static int IAP_List(lua_State* L)
 {
     DM_LUA_STACK_CHECK(L, 0);
@@ -210,6 +215,7 @@ static const luaL_reg IAP_methods[] =
     {"restore", IAP_Restore},
     {"set_listener", IAP_SetListener},
     {"get_provider_id", IAP_GetProviderId},
+    {"process_pending_transactions", IAP_ProcessPendingTransactions},
     {0, 0}
 };
 

--- a/extension-iap/src/iap_ios.mm
+++ b/extension-iap/src/iap_ios.mm
@@ -29,6 +29,7 @@ struct IAP
     NSMutableDictionary*            m_PendingTransactions;
     dmScript::LuaCallbackInfo*      m_Listener;
     IAPCommandQueue                 m_CommandQueue;
+    IAPCommandQueue                 m_ObservableQueue;
     SKPaymentTransactionObserver*   m_Observer;
 };
 
@@ -324,28 +325,25 @@ static void HandlePurchaseResult(IAPCommand* cmd)
     assert(top == lua_gettop(L));
 }
 
-@implementation SKPaymentTransactionObserver
-    - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions
-    {
-        for (SKPaymentTransaction* transaction in transactions) {
-
-            if ((!self.m_IAP->m_AutoFinishTransactions) && (transaction.transactionState == SKPaymentTransactionStatePurchased)) {
+static void processTransactions(IAP* m_IAP, NSArray* transactions) {
+    for (SKPaymentTransaction* transaction in transactions) {
+            if ((!m_IAP->m_AutoFinishTransactions) && (transaction.transactionState == SKPaymentTransactionStatePurchased)) {
                 NSData *data = [transaction.transactionIdentifier dataUsingEncoding:NSUTF8StringEncoding];
                 uint64_t trans_id_hash = dmHashBuffer64((const char*) [data bytes], [data length]);
-                [self.m_IAP->m_PendingTransactions setObject:transaction forKey:[NSNumber numberWithInteger:trans_id_hash] ];
+                [m_IAP->m_PendingTransactions setObject:transaction forKey:[NSNumber numberWithInteger:trans_id_hash] ];
             }
 
-            if (!self.m_IAP->m_Listener)
+            if (!m_IAP->m_Listener)
                 continue;
 
             IAPTransaction* iap_transaction = new IAPTransaction;
             CopyTransaction(transaction, iap_transaction);
 
             IAPCommand cmd;
-            cmd.m_Callback = self.m_IAP->m_Listener;
+            cmd.m_Callback = m_IAP->m_Listener;
             cmd.m_Command = IAP_PURCHASE_RESULT;
             cmd.m_Data = iap_transaction;
-            IAP_Queue_Push(&self.m_IAP->m_CommandQueue, &cmd);
+            IAP_Queue_Push(&m_IAP->m_ObservableQueue, &cmd);
 
             switch (transaction.transactionState)
             {
@@ -363,7 +361,19 @@ static void HandlePurchaseResult(IAPCommand* cmd)
                 default:
                     break;
             }
-        }
+    }
+}
+
+static int IAP_ProcessPendingTransactions(lua_State* L)
+{
+    processTransactions(&g_IAP, [SKPaymentQueue defaultQueue].transactions);
+    return 0;
+}
+
+@implementation SKPaymentTransactionObserver
+    - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions
+    {
+        processTransactions(self.m_IAP, transactions);
     }
 @end
 
@@ -477,18 +487,6 @@ static int IAP_SetListener(lua_State* L)
         dmScript::DestroyCallback(iap->m_Listener);
 
     iap->m_Listener = dmScript::CreateCallback(L, 1);
-
-    if (g_IAP.m_Observer == 0) {
-        SKPaymentTransactionObserver* observer = [[SKPaymentTransactionObserver alloc] init];
-        observer.m_IAP = &g_IAP;
-        // NOTE: We add the listener *after* a lua listener is set
-        // The payment queue is persistent and "old" transaction might be processed
-        // from previous session. We call "finishTransaction" when appropriate
-        // for all transaction and we must ensure that the result is delivered to lua.
-        [[SKPaymentQueue defaultQueue] addTransactionObserver: observer];
-        g_IAP.m_Observer = observer;
-    }
-
     return 0;
 }
 
@@ -506,6 +504,7 @@ static const luaL_reg IAP_methods[] =
     {"restore", IAP_Restore},
     {"set_listener", IAP_SetListener},
     {"get_provider_id", IAP_GetProviderId},
+    {"process_pending_transactions", IAP_ProcessPendingTransactions},
     {0, 0}
 };
 
@@ -520,6 +519,7 @@ static dmExtension::Result InitializeIAP(dmExtension::Params* params)
     g_IAP.m_InitCount++;
 
     IAP_Queue_Create(&g_IAP.m_CommandQueue);
+    IAP_Queue_Create(&g_IAP.m_ObservableQueue);
 
     lua_State*L = params->m_L;
     int top = lua_gettop(L);
@@ -535,6 +535,12 @@ static dmExtension::Result InitializeIAP(dmExtension::Params* params)
 
     lua_pop(L, 1);
     assert(top == lua_gettop(L));
+
+    SKPaymentTransactionObserver* observer = [[SKPaymentTransactionObserver alloc] init];
+    observer.m_IAP = &g_IAP;
+    [[SKPaymentQueue defaultQueue] addTransactionObserver: observer];
+    g_IAP.m_Observer = observer;
+
     return dmExtension::RESULT_OK;
 }
 
@@ -557,6 +563,9 @@ static void IAP_OnCommand(IAPCommand* cmd, void*)
 static dmExtension::Result UpdateIAP(dmExtension::Params* params)
 {
     IAP_Queue_Flush(&g_IAP.m_CommandQueue, IAP_OnCommand, 0);
+    if (g_IAP.m_Observer) {
+        IAP_Queue_Flush(&g_IAP.m_ObservableQueue, IAP_OnCommand, 0);
+    }
     return dmExtension::RESULT_OK;
 }
 
@@ -585,6 +594,7 @@ static dmExtension::Result FinalizeIAP(dmExtension::Params* params)
     }
 
     IAP_Queue_Destroy(&g_IAP.m_CommandQueue);
+    IAP_Queue_Destroy(&g_IAP.m_ObservableQueue);
 
     return dmExtension::RESULT_OK;
 }

--- a/extension-iap/src/iap_ios.mm
+++ b/extension-iap/src/iap_ios.mm
@@ -325,25 +325,25 @@ static void HandlePurchaseResult(IAPCommand* cmd)
     assert(top == lua_gettop(L));
 }
 
-static void processTransactions(IAP* m_IAP, NSArray* transactions) {
+static void processTransactions(IAP* iap, NSArray* transactions) {
     for (SKPaymentTransaction* transaction in transactions) {
-            if ((!m_IAP->m_AutoFinishTransactions) && (transaction.transactionState == SKPaymentTransactionStatePurchased)) {
+            if ((!iap->m_AutoFinishTransactions) && (transaction.transactionState == SKPaymentTransactionStatePurchased)) {
                 NSData *data = [transaction.transactionIdentifier dataUsingEncoding:NSUTF8StringEncoding];
                 uint64_t trans_id_hash = dmHashBuffer64((const char*) [data bytes], [data length]);
-                [m_IAP->m_PendingTransactions setObject:transaction forKey:[NSNumber numberWithInteger:trans_id_hash] ];
+                [iap->m_PendingTransactions setObject:transaction forKey:[NSNumber numberWithInteger:trans_id_hash] ];
             }
 
-            if (!m_IAP->m_Listener)
+            if (!iap->m_Listener)
                 continue;
 
             IAPTransaction* iap_transaction = new IAPTransaction;
             CopyTransaction(transaction, iap_transaction);
 
             IAPCommand cmd;
-            cmd.m_Callback = m_IAP->m_Listener;
+            cmd.m_Callback = iap->m_Listener;
             cmd.m_Command = IAP_PURCHASE_RESULT;
             cmd.m_Data = iap_transaction;
-            IAP_Queue_Push(&m_IAP->m_ObservableQueue, &cmd);
+            IAP_Queue_Push(&iap->m_ObservableQueue, &cmd);
 
             switch (transaction.transactionState)
             {

--- a/extension-iap/src/java/com/defold/iap/IListProductsListener.java
+++ b/extension-iap/src/java/com/defold/iap/IListProductsListener.java
@@ -1,5 +1,5 @@
 package com.defold.iap;
 
 public interface IListProductsListener {
-	public void onProductsResult(int resultCode, String productList);
+	public void onProductsResult(int resultCode, String productList, long cmdHandle);
 }

--- a/extension-iap/src/java/com/defold/iap/IapGooglePlay.java
+++ b/extension-iap/src/java/com/defold/iap/IapGooglePlay.java
@@ -238,7 +238,7 @@ public class IapGooglePlay implements Handler.Callback {
         });
     }
 
-    public void listItems(final String skus, final IListProductsListener listener) {
+    public void listItems(final String skus, final IListProductsListener listener, final long commandPtr) {
         ArrayList<String> skuList = new ArrayList<String>();
         for (String x : skus.split(",")) {
             if (x.trim().length() > 0) {
@@ -261,15 +261,15 @@ public class IapGooglePlay implements Handler.Callback {
                                 products.put(key, convertProduct(product));
                             }
                         }
-                        listener.onProductsResult(resultCode, products.toString());
+                        listener.onProductsResult(resultCode, products.toString(), commandPtr);
                     }
                     catch(JSONException e) {
                         Log.wtf(TAG, "Failed to convert products", e);
-                        listener.onProductsResult(resultCode, null);
+                        listener.onProductsResult(resultCode, null, commandPtr);
                     }
                 }
                 else {
-                    listener.onProductsResult(resultCode, null);
+                    listener.onProductsResult(resultCode, null, commandPtr);
                 }
             }
         }));

--- a/extension-iap/src/java/com/defold/iap/IapJNI.java
+++ b/extension-iap/src/java/com/defold/iap/IapJNI.java
@@ -23,7 +23,7 @@ public class IapJNI implements IListProductsListener, IPurchaseListener {
     }
 
     @Override
-    public native void onProductsResult(int responseCode, String productList);
+    public native void onProductsResult(int responseCode, String productList, long cmdHandle);
 
     @Override
     public native void onPurchaseResult(int responseCode, String purchaseData);


### PR DESCRIPTION
Android fix: Pass a callback pointer to the native code to avoid the issue with multiple calls product list function.
Android and iOs: Add the "process_pending_transactions" function which can be called to process started but not completed transactions (before they was pending forever and was blocking buying the same product again).
Fix is pretty massive sorry for that.