### PR TITLE
Fix crashes when using Amazon provider

### DIFF
--- a/extension-iap/src/java/com/defold/iap/IapAmazon.java
+++ b/extension-iap/src/java/com/defold/iap/IapAmazon.java
@@ -97,6 +97,10 @@ public class IapAmazon implements PurchasingListener {
         }
         PurchasingService.notifyFulfillment(receipt, FulfillmentResult.FULFILLED);
     }
+    
+    public void acknowledgeTransaction(final String purchaseToken, final IPurchaseListener purchaseListener) {
+        // Stub to prevent errors.
+    }
 
     private void doGetPurchaseUpdates(final IPurchaseListener listener, final boolean reset) {
         synchronized (purchaseListeners) {

--- a/extension-iap/src/java/com/defold/iap/IapAmazon.java
+++ b/extension-iap/src/java/com/defold/iap/IapAmazon.java
@@ -45,6 +45,7 @@ public class IapAmazon implements PurchasingListener {
         this.activity = activity;
         this.autoFinishTransactions = autoFinishTransactions;
         this.listProductsListeners = new HashMap<RequestId, IListProductsListener>();
+        this.listProductsCommandPtrs = new HashMap<RequestId, Long>();
         this.purchaseListeners = new HashMap<RequestId, IPurchaseListener>();
         PurchasingService.registerListener(activity, this);
     }


### PR DESCRIPTION
Porting my game to Amazon Appstore and came across a couple crashes.  I have not tested full functionality of purchasing yet, but I'll be sure to keep you updated on how it goes.

The first commit fixes the error below, a `NullPointerException` since one of the HashMaps was not initialized.

```
10-17 11:14:45.564 16211 16268 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.util.HashMap.put(java.lang.Object, java.lang.Object)' on a null object reference
10-17 11:14:45.564 16211 16268 E AndroidRuntime:        at com.defold.iap.IapAmazon.listItems(IapAmazon.java:75)
```

The second commit puts in a stubbed out `acknowledgeTransaction` method, since the JNI code was expecting it to be there and crashed.