### PR TITLE
Fix bug when calling sys.reboot on iOS

### DIFF
--- a/extension-iap/src/iap_ios.mm
+++ b/extension-iap/src/iap_ios.mm
@@ -593,7 +593,10 @@ static dmExtension::Result UpdateIAP(dmExtension::Params* params)
 
 static dmExtension::Result FinalizeIAP(dmExtension::Params* params)
 {
-    dmScript::DestroyCallback(g_IAP.m_Listener);
+    if(g_IAP.m_Listener){
+         dmScript::DestroyCallback(g_IAP.m_Listener);
+    }
+   
     g_IAP.m_Listener = 0;
 
     if (g_IAP.m_PendingTransactions) {


### PR DESCRIPTION
Sys.reboot() crashes on iOS due to a nullpointer in the finalize method. This fixes the issue.