### PR TITLE
Fix bundling for Android 12 SDK

### DIFF
--- a/extension-iap/manifests/android/AndroidManifest.xml
+++ b/extension-iap/manifests/android/AndroidManifest.xml
@@ -4,9 +4,9 @@
 <uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
     <application>
         <!-- For Amazon IAP -->
-        <receiver android:exported="true" android:name = "com.amazon.device.iap.ResponseReceiver" android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
+        <receiver android:exported="true" android:name="com.amazon.device.iap.ResponseReceiver" android:permission="com.amazon.inapp.purchasing.Permission.NOTIFY">
             <intent-filter>
-                <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
+                <action android:name="com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>
         </receiver>
     </application>

--- a/extension-iap/manifests/android/AndroidManifest.xml
+++ b/extension-iap/manifests/android/AndroidManifest.xml
@@ -4,7 +4,7 @@
 <uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
     <application>
         <!-- For Amazon IAP -->
-        <receiver android:name = "com.amazon.device.iap.ResponseReceiver" android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
+        <receiver android:exported="true" android:name = "com.amazon.device.iap.ResponseReceiver" android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
             <intent-filter>
                 <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>


### PR DESCRIPTION
Bundling previously failed with:

```
Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```