### PR TITLE
Check that the purchase listener is not null

### DIFF
--- a/game.project
+++ b/game.project
@@ -16,7 +16,7 @@ target_sdk_version = 29
 
 [project]
 title = extension-iap
-dependencies = https://github.com/andsve/dirtylarry/archive/master.zip
+dependencies#0 = https://github.com/andsve/dirtylarry/archive/master.zip
 
 [library]
 include_dirs = extension-iap


### PR DESCRIPTION
This change makes sure to check that the purchase listener is not null before trying to call it with a purchase result.

Fixes #56 