### PR TITLE
Migrate Android R8 rules and fix Core dependency

### DIFF
--- a/extension-iap/manifests/android/build.gradle
+++ b/extension-iap/manifests/android/build.gradle
@@ -4,4 +4,6 @@ repositories {
 
 dependencies {
     implementation 'com.android.billingclient:billing:8.3.0'
+    // Billing's Play Services graph uses PendingIntentCompat but resolves Core 1.9.0.
+    implementation 'androidx.core:core:1.10.1'
 }

--- a/extension-iap/manifests/android/extension-iap.keep
+++ b/extension-iap/manifests/android/extension-iap.keep
@@ -1,0 +1,8 @@
+# Native code loads the Defold IAP classes and invokes their methods by name.
+-keep,allowoptimization class com.defold.iap.** { *; }
+
+# The Amazon Appstore IAP SDK uses reflection and requires these rules.
+# https://developer.amazon.com/docs/in-app-purchasing/iap-obfuscate-the-code.html
+-dontwarn com.amazon.**
+-keep class com.amazon.** { *; }
+-keepattributes *Annotation*

--- a/extension-iap/manifests/android/extension-iap.pro
+++ b/extension-iap/manifests/android/extension-iap.pro
@@ -1,4 +1,0 @@
--keep class com.defold.iap.** {
-    public <methods>;
-}
-


### PR DESCRIPTION
Native Android code loads this extension's Java bridge and invokes its methods by name through JNI. Add `extension-iap/manifests/android/extension-iap.keep` to preserve those classes and members during R8 shrinking and obfuscation.

Replaces the previous ProGuard file, includes Amazon IAP reflection rules, and adds AndroidX Core 1.10.1.

Applies the changes from `aa3b0f2539b009e219844643f72d64724506906d` on the latest `master`.

Validation: checked the Java bridge and native JNI references; verified that the branch contains one commit with the same patch as the supplied commit; `git diff --check` passes. Android builds and device tests were not run for this PR preparation.
